### PR TITLE
Improve detection of Warlock's demonology spec

### DIFF
--- a/c_player_classes.py
+++ b/c_player_classes.py
@@ -398,7 +398,6 @@ SPELL_BOOK_SPEC = {
         "47847": 3, # Shadowfury
         "17962": 3, # Conflagrate (Rank 1)
         "30912": 3, # Conflagrate (Rank 6)
-        "18871": 3, # Shadowburn
     },
     "warrior": {
         "7384": 1, # Overpower

--- a/c_player_classes.py
+++ b/c_player_classes.py
@@ -392,6 +392,7 @@ SPELL_BOOK_SPEC = {
         "47241": 2, # Metamorphosis
         "63167": 2, # Decimation
         "47193": 2, # Demonic Empowerment
+        "32553": 2, # Life Tap # SPELL_ENERGIZE Mana Feed
 
         "59172": 3, # Chaos Bolt
         "47847": 3, # Shadowfury

--- a/logs_player_spec.py
+++ b/logs_player_spec.py
@@ -44,6 +44,7 @@ def get_specs(logs: list[str], players: dict[str, str], classes: dict[str, str],
             continue
         spec = CLASSES_LIST_HTML.index(player_class) * 4
         if player_class == "warlock":
+            # default to Destruction spec if it could not be detected
             spec += 3
         SPECS[player_guid] = spec
 


### PR DESCRIPTION
This PR adds an additional spell, `Life Tap with Mana Feed`, to detect the Demonology specialization and removes `Shadowburn` from the Destruction detection, as it is used by both specs. Additionally, I have added a brief comment regarding the default Warlock specialization, as I found it slightly unclear as a new contributor.

The primary motivation for this change is that this combat log parser is widely used on Warmane Onyxia TBC server. Currently, Demonology specialization is not detected correctly because `Molten Core`, `Metamorphosis`, `Decimation`, and `Demonic Empowerment` do not exist in this expansion.