### PR TITLE
Display spell IDs in comparison page

### DIFF
--- a/static/compare.js
+++ b/static/compare.js
@@ -56,7 +56,7 @@ function add_spells(spells) {
   SELECT_SPELL.innerHTML = "";
   SELECT_SPELL.style.display = object_is_empty(spells) ? "none" : "";
   for (const id in spells) {
-    SELECT_SPELL.appendChild(new_option(id, spells[id]["name"]));
+    SELECT_SPELL.appendChild(new_option(id, `${spells[id]['name']} [${id.split('--')[0]}]`));
   }
 }
 


### PR DESCRIPTION
In the comparison page, the spell dropdown can have duplicate names if multiple ranks of the same spell are present. For example, in the image below there are two `Corruption` spells:

![image](https://github.com/user-attachments/assets/806ed5ed-9ecc-469a-9c85-3968d9c5d0c2)

<br>

This PR adds the spell ID as part of the name, resulting in:
![image](https://github.com/user-attachments/assets/b9e9e12a-5483-497b-ba8e-feaf64a8312a)

The string truncation is needed to remove GUIDs from spells used by pets/minions.